### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 A Model Context Protocol (MCP) server built with mcp-framework that provides an image generation tool using Templated.io.
 
+<a href="https://glama.ai/mcp/servers/p9zgbaq5ll">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/p9zgbaq5ll/badge" alt="TemplateIO MCP server" />
+</a>
+
 ## Overview
 
 This template provides a starting point for building MCP servers with custom tools. It includes an example tool and instructions on how to add more tools, develop them, and publish them to npm. This README will guide you through the process of setting up, developing, and deploying your own MCP server.


### PR DESCRIPTION
This PR adds a badge for the [MCP TemplateIO](https://glama.ai/mcp/servers/p9zgbaq5ll) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/p9zgbaq5ll">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/p9zgbaq5ll/badge" alt="TemplateIO MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.